### PR TITLE
feat: implement flat_map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,74 @@ rail-*.tar
 /tmp/
 
 mix.lock
+
+# Created by https://www.toptal.com/developers/gitignore/api/macos,linux,visualstudiocode
+# Edit at https://www.toptal.com/developers/gitignore?templates=macos,linux,visualstudiocode
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+### VisualStudioCode ###
+.vscode/*
+# !.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+# End of https://www.toptal.com/developers/gitignore/api/macos,linux,visualstudiocode

--- a/lib/rail.ex
+++ b/lib/rail.ex
@@ -377,7 +377,7 @@ defmodule Rail do
   def normalize(untagged), do: {:ok, untagged}
 
   @doc """
-  Apply a function for value of {:ok, value}, otherwise bypass
+  Return a new tuple for value of {:ok, value}, otherwise bypass
 
   ## Examples
 
@@ -393,7 +393,7 @@ defmodule Rail do
   def flat_map_ok(other, _), do: other
 
   @doc """
-  Apply a function for error of {:error, error}, otherwise bypass
+  Return a new tuple for error of {:error, error}, otherwise bypass
 
   ## Examples
 

--- a/lib/rail.ex
+++ b/lib/rail.ex
@@ -345,6 +345,8 @@ defmodule Rail do
       :error
       iex> {:error, :noent} |> Rail.map_error(fn :noent -> :not_found end)
       {:error, :not_found}
+      iex> {:ok, 1} |> Rail.map_error(fn :noent -> :not_found end)
+      {:ok, 1}
 
   """
   def map_error({:error, value}, fun) when is_function(fun, 1), do: {:error, fun.(value)}
@@ -373,4 +375,36 @@ defmodule Rail do
   def normalize({tag, v1, v2, v3}) when tag in [:ok, :error], do: {tag, {v1, v2, v3}}
   def normalize({tag, v1, v2, v3, v4}) when tag in [:ok, :error], do: {tag, {v1, v2, v3, v4}}
   def normalize(untagged), do: {:ok, untagged}
+
+  @doc """
+  Apply a function for value of {:ok, value}, otherwise bypass
+
+  ## Examples
+
+      iex> :ok |> Rail.flat_map_ok(fn 1 -> {:noreply, 10} end)
+      :ok
+      iex> {:ok, 1} |> Rail.flat_map_ok(fn 1 -> {:noreply, 10} end)
+      {:noreply, 10}
+      iex> {:error, 1} |> Rail.flat_map_ok(fn 1 -> {:noreply, 10} end)
+      {:error, 1}
+
+  """
+  def flat_map_ok({:ok, value}, fun) when is_function(fun, 1), do: fun.(value)
+  def flat_map_ok(other, _), do: other
+
+  @doc """
+  Apply a function for error of {:error, error}, otherwise bypass
+
+  ## Examples
+
+      iex> :error |> Rail.flat_map_error(fn :noent -> {:noreply, :not_found} end)
+      :error
+      iex> {:error, :noent} |> Rail.flat_map_error(fn :noent -> {:noreply, :not_found} end)
+      {:noreply, :not_found}
+      iex> {:ok, 1} |> Rail.flat_map_error(fn :noent -> {:noreply, :not_found} end)
+      {:ok, 1}
+
+  """
+  def flat_map_error({:error, value}, fun) when is_function(fun, 1), do: fun.(value)
+  def flat_map_error(other, _), do: other
 end


### PR DESCRIPTION
- Add `flat_map_ok` and `flat_map_error` for convenience
  - Naming reference: https://developer.apple.com/documentation/swift/result/flatmaperror(_:)
- Update .gitignore with a template created by gitignore.io

## Use case
```diff
- @impl Phoenix.LiveView
- def handle_event("save", %{"form" => form}, socket) do
-   socket.assigns.form
-   |> AshPhoenix.Form.validate(form)
-   |> AshPhoenix.Form.submit()
-   |> case do
-     {:ok, _result} -> {:noreply, push_navigate(socket, to: ~p"/")}
-     {:error, form} -> {:noreply, assign(socket, :form, form)}
-   end
- end
+ @impl Phoenix.LiveView
+ def handle_event("save", %{"form" => form}, socket) do
+   rail do
+     form = AshPhoenix.Form.validate(form, socket.assigns.form)
+     _result <- AshPhoenix.Form.submit(form)
+     {:noreply, push_navigate(socket, to: ~p"/")}
+   end
+   |> Rail.flat_map_error(fn form -> {:noreply, assign(socket, :form, form)} end)
+ end
```
